### PR TITLE
Add Google Cloud STT integration

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -23,3 +23,11 @@
 - `app/` - Main backend application code
 - `tests/` - Test cases
 - `scripts/` - Utility scripts
+
+## Speech-to-Text
+
+The backend integrates with **Google Cloud Speech-to-Text**. Set the
+`GOOGLE_APPLICATION_CREDENTIALS` environment variable to your service account
+JSON file before running the app. A WebSocket endpoint is available at
+`/api/v1/stt/ws/stt` for streaming recognition, and `/api/v1/stt/transcribe` can
+be used to transcribe uploaded audio files.

--- a/backend/app/api/v1/endpoints/stt.py
+++ b/backend/app/api/v1/endpoints/stt.py
@@ -1,12 +1,29 @@
-from fastapi import APIRouter, WebSocket
-from app.services.stt_client import speech_to_text
+from fastapi import APIRouter, WebSocket, UploadFile, File, WebSocketDisconnect
+from app.services.stt_client import (
+    speech_to_text,
+    streaming_speech_to_text,
+)
 
 router = APIRouter()
 
 @router.websocket("/ws/stt")
 async def websocket_stt(websocket: WebSocket):
     await websocket.accept()
-    while True:
-        audio_bytes = await websocket.receive_bytes()
-        text = await speech_to_text(audio_bytes)
-        await websocket.send_text(text)
+    async def chunk_generator():
+        try:
+            while True:
+                chunk = await websocket.receive_bytes()
+                yield chunk
+        except WebSocketDisconnect:
+            return
+
+    transcript = await streaming_speech_to_text(chunk_generator())
+    await websocket.send_text(transcript)
+
+
+@router.post("/transcribe")
+async def transcribe_audio(file: UploadFile = File(...)):
+    """Transcribe an uploaded audio file."""
+    audio_bytes = await file.read()
+    text = await speech_to_text(audio_bytes)
+    return {"transcript": text}

--- a/backend/app/services/stt_client.py
+++ b/backend/app/services/stt_client.py
@@ -1,6 +1,69 @@
 import asyncio
+from typing import AsyncIterable
+from google.cloud import speech_v1p1beta1 as speech
 
-async def speech_to_text(audio_bytes: bytes) -> str:
-    # Dummy: In real use, call your STT API/service here
-    # Return transcribed text
-    return "Transcribed text placeholder"
+client = speech.SpeechClient()
+
+
+def _config(language_code: str) -> speech.RecognitionConfig:
+    """Return recognition config with multiple regional languages."""
+    return speech.RecognitionConfig(
+        encoding=speech.RecognitionConfig.AudioEncoding.LINEAR16,
+        sample_rate_hertz=16000,
+        language_code=language_code,
+        alternative_language_codes=[
+            "hi-IN",
+            "en-IN",
+            "bn-IN",
+            "gu-IN",
+            "kn-IN",
+            "ml-IN",
+            "mr-IN",
+            "pa-IN",
+            "ta-IN",
+            "te-IN",
+        ],
+        enable_automatic_punctuation=True,
+    )
+
+
+async def speech_to_text(audio_bytes: bytes, language_code: str = "hi-IN") -> str:
+    """Transcribe a block of audio bytes using Google STT."""
+
+    def _recognize() -> str:
+        audio = speech.RecognitionAudio(content=audio_bytes)
+        response = client.recognize(config=_config(language_code), audio=audio)
+        return " ".join(r.alternatives[0].transcript for r in response.results)
+
+    return await asyncio.to_thread(_recognize)
+
+
+async def speech_to_text_from_file(file_path: str, language_code: str = "hi-IN") -> str:
+    """Convenience wrapper to transcribe an audio file."""
+    with open(file_path, "rb") as f:
+        audio_bytes = f.read()
+    return await speech_to_text(audio_bytes, language_code)
+
+
+async def streaming_speech_to_text(
+    chunks: AsyncIterable[bytes], language_code: str = "hi-IN"
+) -> str:
+    """Transcribe audio streamed in chunks."""
+    collected = [chunk async for chunk in chunks]
+
+    def _stream() -> str:
+        requests = (
+            speech.StreamingRecognizeRequest(audio_content=c) for c in collected
+        )
+        streaming_config = speech.StreamingRecognitionConfig(
+            config=_config(language_code),
+            interim_results=False,
+        )
+        responses = client.streaming_recognize(streaming_config, requests)
+        transcripts = []
+        for response in responses:
+            for result in response.results:
+                transcripts.append(result.alternatives[0].transcript)
+        return " ".join(transcripts)
+
+    return await asyncio.to_thread(_stream)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ langchain-google-genai
 chromadb
 beautifulsoup4
 lxml
+google-cloud-speech


### PR DESCRIPTION
## Summary
- integrate Google Speech‑to‑Text in `stt_client.py`
- support uploaded audio files and streaming WebSocket transcription
- document STT usage and Google credentials
- add `google-cloud-speech` to backend requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68838121e988832cb630e2cf9584575c