### PR TITLE
Implement simple multi‑agent framework

### DIFF
--- a/backend/app/agents/base.py
+++ b/backend/app/agents/base.py
@@ -1,0 +1,11 @@
+from app.services.gemini_client import call_gemini
+
+class Agent:
+    """Simple Gemini-powered agent that formats a prompt and returns the result."""
+
+    def __init__(self, prompt_template: str):
+        self.prompt_template = prompt_template
+
+    def run(self, **kwargs) -> str:
+        prompt = self.prompt_template.format(**kwargs)
+        return call_gemini(prompt)

--- a/backend/app/agents/market_agent.py
+++ b/backend/app/agents/market_agent.py
@@ -1,0 +1,11 @@
+from .base import Agent
+
+MARKET_ANALYSIS_PROMPT = (
+    "You are a market price analyst. Given the data {market_data} and the farmer's question '{query}', "
+    "give short advice about market trends."
+)
+
+market_agent = Agent(MARKET_ANALYSIS_PROMPT)
+
+def analyze_market(query: str, market_data: dict) -> str:
+    return market_agent.run(query=query, market_data=str(market_data))

--- a/backend/app/agents/planner_agent.py
+++ b/backend/app/agents/planner_agent.py
@@ -1,0 +1,16 @@
+from .base import Agent
+
+PLANNER_PROMPT = (
+    "You are a planning agent for an agricultural assistant. "
+    "Given the farmer's query: '{query}', decide which of the following tasks are needed: "
+    "WEATHER and/or MARKET. Respond with a comma separated list using lowercase names."
+)
+
+planner_agent = Agent(PLANNER_PROMPT)
+
+
+def plan_tasks(query: str) -> list[str]:
+    """Return a list of tasks suggested by the planner agent."""
+    response = planner_agent.run(query=query)
+    tasks = [task.strip().lower() for task in response.split(',') if task.strip()]
+    return tasks

--- a/backend/app/agents/summary_agent.py
+++ b/backend/app/agents/summary_agent.py
@@ -1,0 +1,12 @@
+from .base import Agent
+
+SUMMARY_PROMPT = (
+    "You are an expert agricultural advisor summarizing inputs from different agents. "
+    "Using the farmer's question '{query}', the weather advice '{weather}', and the market advice '{market}', "
+    "write a final concise recommendation."
+)
+
+summary_agent = Agent(SUMMARY_PROMPT)
+
+def summarize(query: str, weather: str, market: str) -> str:
+    return summary_agent.run(query=query, weather=weather, market=market)

--- a/backend/app/agents/weather_agent.py
+++ b/backend/app/agents/weather_agent.py
@@ -1,0 +1,11 @@
+from .base import Agent
+
+WEATHER_ANALYSIS_PROMPT = (
+    "You are a weather analysis expert. Using the data {weather_data} and considering the farmer's question '{query}', "
+    "provide short actionable advice about the weather."
+)
+
+weather_agent = Agent(WEATHER_ANALYSIS_PROMPT)
+
+def analyze_weather(query: str, weather_data: dict) -> str:
+    return weather_agent.run(query=query, weather_data=str(weather_data))

--- a/backend/app/services/coordinator_service.py
+++ b/backend/app/services/coordinator_service.py
@@ -1,81 +1,34 @@
-# app/services/coordinator_service.py
+"""Service to coordinate multiple Gemini-powered agents."""
 
-import httpx
-import os
-from dotenv import load_dotenv
-from app.utils.prompt_manager import render_prompt
-from app.services.gemini_client import call_gemini
-# We will add the RAG tool here in Task 3
-# from .rag_service import query_community_knowledge 
+from app.services.data_tools import fetch_weather_data, fetch_market_data
+from app.agents.planner_agent import plan_tasks
+from app.agents.weather_agent import analyze_weather
+from app.agents.market_agent import analyze_market
+from app.agents.summary_agent import summarize
 
-load_dotenv()
 
-DATA_GOV_IN_API_KEY = os.getenv("DATA_GOV_IN_API_KEY")
-OPENWEATHER_API_KEY = os.getenv("OPENWEATHER_API_KEY")
+async def get_holistic_advisory(
+    query: str,
+    lat: float,
+    lon: float,
+    state: str,
+    district: str,
+    market: str,
+    commodity: str,
+) -> dict:
+    """Coordinate planner, weather and market agents to answer a farmer query."""
 
-# Tool 1: Get Weather Data
-async def get_weather_data(lat: float, lon: float):
-    """Fetches weather data from OpenWeatherMap."""
-    url = f"https://api.openweathermap.org/data/2.5/forecast?lat={lat}&lon={lon}&appid={OPENWEATHER_API_KEY}&units=metric"
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.get(url)
-            response.raise_for_status()
-            return response.json()
-        except httpx.HTTPStatusError as e:
-            print(f"Weather API HTTP error: {e.response.text}")
-            return {"error": "Could not fetch weather data."}
-        except Exception as e:
-            print(f"Weather API error: {str(e)}")
-            return {"error": "An unexpected error occurred while fetching weather data."}
+    tasks = plan_tasks(query)
+    weather_text = ""
+    market_text = ""
 
-# Tool 2: Get Market Data
-async def get_market_data(state: str, district: str, market: str, commodity: str):
-    """Fetches market price data from data.gov.in."""
-    base_url = "https://api.data.gov.in/resource/9ef84268-d588-465a-a308-a864a43d0070"
-    params = {
-        "api-key": DATA_GOV_IN_API_KEY,
-        "format": "json",
-        "limit": 10, # Fetch recent records
-        "filters[state]": state,
-        "filters[district]": district,
-        "filters[market]": market,
-        "filters[commodity]": commodity,
-    }
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.get(base_url, params=params)
-            response.raise_for_status()
-            return response.json()
-        except httpx.HTTPStatusError as e:
-            print(f"Market Data API HTTP error: {e.response.text}")
-            return {"error": "Could not fetch market data."}
-        except Exception as e:
-            print(f"Market Data API error: {str(e)}")
-            return {"error": "An unexpected error occurred while fetching market data."}
+    if "weather" in tasks:
+        weather_data = await fetch_weather_data(lat, lon)
+        weather_text = analyze_weather(query, weather_data)
 
-# Main Orchestrator Logic
-async def get_holistic_advisory(query: str, lat: float, lon: float, state: str, district: str, market: str, commodity: str) -> dict:
-    """
-    The main coordinator function. It calls tools and synthesizes a response.
-    """
-    # 1. Fetch data from all sources concurrently (or sequentially for simplicity first)
-    weather_data = await get_weather_data(lat, lon)
-    market_data = await get_market_data(state, district, market, commodity)
+    if "market" in tasks:
+        market_data = await fetch_market_data(state, district, market, commodity)
+        market_text = analyze_market(query, market_data)
 
-    # In Task 3, we will add the community knowledge tool call here
-    # community_insights = await query_community_knowledge(query)
-
-    # 2. Render the prompt with all the fetched data
-    prompt = render_prompt(
-        name="advisory_prompt",
-        query=query,
-        weather_data=str(weather_data),
-        market_data=str(market_data),
-        # community_insights=str(community_insights) # Add this in Task 3
-    )
-
-    # 3. Call Gemini to get the final synthesized response
-    final_response = call_gemini(prompt)
-
+    final_response = summarize(query, weather_text, market_text)
     return {"response": final_response}

--- a/backend/app/services/data_tools.py
+++ b/backend/app/services/data_tools.py
@@ -1,0 +1,45 @@
+import httpx
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DATA_GOV_IN_API_KEY = os.getenv("DATA_GOV_IN_API_KEY")
+OPENWEATHER_API_KEY = os.getenv("OPENWEATHER_API_KEY")
+
+async def fetch_weather_data(lat: float, lon: float):
+    url = f"https://api.openweathermap.org/data/2.5/forecast?lat={lat}&lon={lon}&appid={OPENWEATHER_API_KEY}&units=metric"
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(url)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            print(f"Weather API HTTP error: {e.response.text}")
+            return {"error": "Could not fetch weather data."}
+        except Exception as e:
+            print(f"Weather API error: {str(e)}")
+            return {"error": "An unexpected error occurred while fetching weather data."}
+
+async def fetch_market_data(state: str, district: str, market: str, commodity: str):
+    base_url = "https://api.data.gov.in/resource/9ef84268-d588-465a-a308-a864a43d0070"
+    params = {
+        "api-key": DATA_GOV_IN_API_KEY,
+        "format": "json",
+        "limit": 10,
+        "filters[state]": state,
+        "filters[district]": district,
+        "filters[market]": market,
+        "filters[commodity]": commodity,
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(base_url, params=params)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            print(f"Market Data API HTTP error: {e.response.text}")
+            return {"error": "Could not fetch market data."}
+        except Exception as e:
+            print(f"Market Data API error: {str(e)}")
+            return {"error": "An unexpected error occurred while fetching market data."}


### PR DESCRIPTION
## Summary
- create new `agents` module with base, planner, weather, market and summary agents
- move data fetching into `data_tools`
- refactor `coordinator_service` to orchestrate multiple agents

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68853b14edd0832c9c7ee65056c31a5a